### PR TITLE
Route wildcard via options

### DIFF
--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -207,6 +207,9 @@ class AuraRouter implements RouterInterface
                 case 'values':
                     $auraRoute->addValues($value);
                     break;
+                case 'wildcard':
+                    $auraRoute->setWildcard($value);
+                    break;
             }
         }
 

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -122,7 +122,7 @@ class AuraRouterTest extends TestCase
         $router->addRoute($route);
         $router->generateUri('foo');
     }
-	
+
     public function testCanSpecifyAuraRouteWildcardViaRouteOptions()
     {
         $route = new Route('/foo', 'foo', ['GET']);

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -122,6 +122,25 @@ class AuraRouterTest extends TestCase
         $router->addRoute($route);
         $router->generateUri('foo');
     }
+	
+    public function testCanSpecifyAuraRouteWildcardViaRouteOptions()
+    {
+        $route = new Route('/foo', 'foo', ['GET']);
+        $route->setOptions(['wildcard' => 'card']);
+
+        $this->auraRoute->setServer([
+            'REQUEST_METHOD' => 'GET',
+        ])->shouldBeCalled();
+        $this->auraRoute->setWildcard($route->getOptions()['wildcard'])->shouldBeCalled();
+
+        $this->auraRouter->add('/foo^GET', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
+        // Injection happens when match() or generateUri() are called
+        $this->auraRouter->generateRaw('foo', [])->willReturn('/foo');
+
+        $router = $this->getRouter();
+        $router->addRoute($route);
+        $router->generateUri('foo');
+    }
 
     public function testMatchingRouteShouldReturnSuccessfulRouteResult()
     {


### PR DESCRIPTION
This PR provides the ability to set Aura route [`wildcard`](https://github.com/auraphp/Aura.Router/blob/3.x/docs/defining-routes.md#wildcard-attributes) via route options.
