### PR TITLE
Populate RouteResult with a Route, and honor HEAD and OPTIONS requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
     - php: 5.6
       env:
         - CS_CHECK=true
     - php: 7
+    - php: 7.1
     - php: hhvm 
   allow_failures:
     - php: hhvm
@@ -28,7 +28,7 @@ install:
 
 script:
   - composer test
-  - if [[ $CS_CHECK == 'true' ]]; then composer cs ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 notifications:
   email: true

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": "^5.5 || ^7.0",
         "aura/router": "^3.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.3.2"
+        "zendframework/zend-expressive-router": "^1.3.2",
+        "fig/http-message-util": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "aura/router": "^3.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.3.2",
@@ -40,10 +40,10 @@
     },
     "scripts": {
         "check": [
-            "@cs",
+            "@cs-check",
             "@test"
         ],
-        "cs": "phpcs",
+        "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit"
     }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.5 || ^7.0",
         "aura/router": "^3.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.0"
+        "zendframework/zend-expressive-router": "^1.3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -178,23 +178,11 @@ class AuraRouter implements RouterInterface
             }
 
             // We store the route name already, so we can match on that
-            // as long it is non-empty.
-            if (! empty($auraRoute->name)
-                && $auraRoute->name === $route->getName()
-            ) {
+            if ($auraRoute->name === $route->getName()) {
                 return $route;
             }
 
-            // Otherwise, we need to look at the path and HTTP method
-            if ($auraRoute->path !== $route->getPath()) {
-                return $matched;
-            }
-
-            if (! $route->allowsMethod($method)) {
-                return $matched;
-            }
-
-            return $route;
+            return false;
         }, false);
 
         if (! $route) {

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -14,6 +14,7 @@ use Aura\Router\Map as AuraMap;
 use Aura\Router\Matcher as AuraMatcher;
 use Aura\Router\Route as AuraRoute;
 use Aura\Router\RouterContainer as AuraRouterContainer;
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -58,7 +59,7 @@ class AuraRouterTest extends TestCase
 
     public function testAddingRouteAggregatesRoute()
     {
-        $route  = new Route('/foo', 'foo', ['GET']);
+        $route  = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
         $router = $this->getRouter();
         $router->addRoute($route);
         $this->assertAttributeContains($route, 'routesToInject', $router);
@@ -71,7 +72,7 @@ class AuraRouterTest extends TestCase
      */
     public function testMatchingInjectsRouteIntoAuraRouter()
     {
-        $route  = new Route('/foo', 'foo', ['GET']);
+        $route  = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
         $router = $this->getRouter();
         $router->addRoute($route);
 
@@ -88,7 +89,7 @@ class AuraRouterTest extends TestCase
         $request->getUri()->will(function () use ($uri) {
             return $uri->reveal();
         });
-        $request->getMethod()->willReturn('GET');
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
         $request->getServerParams()->willReturn([]);
 
         $this->auraMap->addRoute($auraRoute)->shouldBeCalled();
@@ -103,7 +104,7 @@ class AuraRouterTest extends TestCase
      */
     public function testUriGenerationInjectsRouteIntoAuraRouter()
     {
-        $route  = new Route('/foo', 'foo', ['GET']);
+        $route  = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
         $router = $this->getRouter();
         $router->addRoute($route);
 
@@ -121,7 +122,7 @@ class AuraRouterTest extends TestCase
 
     public function testCanSpecifyAuraRouteTokensViaRouteOptions()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
         $route->setOptions(['tokens' => ['foo' => 'bar']]);
 
         $auraRoute = new AuraRoute();
@@ -142,7 +143,7 @@ class AuraRouterTest extends TestCase
 
     public function testCanSpecifyAuraRouteValuesViaRouteOptions()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
         $route->setOptions(['values' => ['foo' => 'bar']]);
 
         $auraRoute = new AuraRoute();
@@ -163,7 +164,7 @@ class AuraRouterTest extends TestCase
 
     public function testCanSpecifyAuraRouteWildcardViaRouteOptions()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
         $route->setOptions(['wildcard' => 'card']);
 
         $auraRoute = new AuraRoute();
@@ -190,14 +191,14 @@ class AuraRouterTest extends TestCase
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getUri()->willReturn($uri);
-        $request->getMethod()->willReturn('GET');
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
         $request->getServerParams()->willReturn([]);
 
         $auraRoute = new AuraRoute();
         $auraRoute->name('/foo');
         $auraRoute->path('/foo');
         $auraRoute->handler('foo');
-        $auraRoute->allows(['GET']);
+        $auraRoute->allows([RequestMethod::METHOD_GET]);
         $auraRoute->attributes([
             'action' => 'foo',
             'bar'    => 'baz',
@@ -206,7 +207,7 @@ class AuraRouterTest extends TestCase
         $this->auraMatcher->match($request)->willReturn($auraRoute);
 
         $router = $this->getRouter();
-        $router->addRoute(new Route('/foo', 'foo', ['GET'], '/foo'));
+        $router->addRoute(new Route('/foo', 'foo', [RequestMethod::METHOD_GET], '/foo'));
         $result = $router->match($request->reveal());
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isSuccess());
@@ -220,20 +221,20 @@ class AuraRouterTest extends TestCase
 
     public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()
     {
-        $route = new Route('/foo', 'foo', ['POST']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_POST]);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getUri()->willReturn($uri);
-        $request->getMethod()->willReturn('GET');
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
         $request->getServerParams()->willReturn([]);
 
         $this->auraMatcher->match($request)->willReturn(false);
 
         $auraRoute = new AuraRoute();
-        $auraRoute->allows(['POST']);
+        $auraRoute->allows([RequestMethod::METHOD_POST]);
 
         $this->auraMatcher->getFailedRoute()->willReturn($auraRoute);
 
@@ -241,19 +242,19 @@ class AuraRouterTest extends TestCase
         $result = $router->match($request->reveal());
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isFailure());
-        $this->assertSame(['POST'], $result->getAllowedMethods());
+        $this->assertSame([RequestMethod::METHOD_POST], $result->getAllowedMethods());
     }
 
     public function testMatchFailureNotDueToHttpMethodReturnsGenericRouteFailureResult()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/bar');
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getUri()->willReturn($uri);
-        $request->getMethod()->willReturn('PUT');
+        $request->getMethod()->willReturn(RequestMethod::METHOD_PUT);
         $request->getServerParams()->willReturn([]);
 
         $this->auraMatcher->match($request)->willReturn(false);
@@ -276,9 +277,9 @@ class AuraRouterTest extends TestCase
     public function testCanGenerateUriFromRoutes()
     {
         $router = new AuraRouter();
-        $route1 = new Route('/foo', 'foo', ['POST'], 'foo-create');
-        $route2 = new Route('/foo', 'foo', ['GET'], 'foo-list');
-        $route3 = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
+        $route1 = new Route('/foo', 'foo', [RequestMethod::METHOD_POST], 'foo-create');
+        $route2 = new Route('/foo', 'foo', [RequestMethod::METHOD_GET], 'foo-list');
+        $route3 = new Route('/foo/{id}', 'foo', [RequestMethod::METHOD_GET], 'foo');
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
 
         $router->addRoute($route1);
@@ -297,14 +298,14 @@ class AuraRouterTest extends TestCase
      */
     public function testReturns404ResultIfAuraReturnsNullForFailedRoute()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/bar');
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getUri()->willReturn($uri);
-        $request->getMethod()->willReturn('PUT');
+        $request->getMethod()->willReturn(RequestMethod::METHOD_PUT);
         $request->getServerParams()->willReturn([]);
 
         $this->auraMatcher->match($request)->willReturn(false);
@@ -324,7 +325,7 @@ class AuraRouterTest extends TestCase
     public function testGeneratedUriIsNotEncoded()
     {
         $router = new AuraRouter();
-        $route  = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
+        $route  = new Route('/foo/{id}', 'foo', [RequestMethod::METHOD_GET], 'foo');
 
         $router->addRoute($route);
 
@@ -336,25 +337,60 @@ class AuraRouterTest extends TestCase
 
     public function testSuccessfulRouteResultComposesMatchedRoute()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', 'foo', [RequestMethod::METHOD_GET]);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getUri()->willReturn($uri);
-        $request->getMethod()->willReturn('GET');
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
         $request->getServerParams()->willReturn([]);
 
         $auraRoute = new AuraRoute();
         $auraRoute->name('/foo');
         $auraRoute->path('/foo');
         $auraRoute->handler('foo');
-        $auraRoute->allows(['GET']);
+        $auraRoute->allows([RequestMethod::METHOD_GET]);
 
         $this->auraMatcher->match($request)->willReturn($auraRoute);
 
         $router = $this->getRouter();
+        $router->addRoute($route);
+
+        $result = $router->match($request->reveal());
+        $this->assertInstanceOf(RouteResult::class, $result);
+        $this->assertTrue($result->isSuccess());
+
+        $matched = $result->getMatchedRoute();
+        $this->assertSame($route, $matched);
+    }
+
+    public function implicitMethods()
+    {
+        return [
+            'head'    => [RequestMethod::METHOD_HEAD],
+            'options' => [RequestMethod::METHOD_OPTIONS],
+        ];
+    }
+
+    /**
+     * @dataProvider implicitMethods
+     */
+    public function testHeadAndOptionsAlwaysResultInRoutingSuccessIfPathMatches($method)
+    {
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getPath()->willReturn('/foo');
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getUri()->willReturn($uri);
+        $request->getMethod()->willReturn($method);
+        $request->getServerParams()->willReturn([]);
+
+        // Not mocking the router container or Aura\Route; this particular test
+        // is testing how the parts integrate.
+        $router = new AuraRouter();
+        $route  = new Route('/foo', 'foo', [RequestMethod::METHOD_POST]);
         $router->addRoute($route);
 
         $result = $router->match($request->reveal());

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -347,15 +347,7 @@ class AuraRouterTest extends TestCase
         $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
         $request->getServerParams()->willReturn([]);
 
-        $auraRoute = new AuraRoute();
-        $auraRoute->name('/foo');
-        $auraRoute->path('/foo');
-        $auraRoute->handler('foo');
-        $auraRoute->allows([RequestMethod::METHOD_GET]);
-
-        $this->auraMatcher->match($request)->willReturn($auraRoute);
-
-        $router = $this->getRouter();
+        $router = new AuraRouter();
         $router->addRoute($route);
 
         $result = $router->match($request->reveal());


### PR DESCRIPTION
The zend-expressive-router 1.3 series provides changes to support two features:

- populating a `RouteResult` with a `Route` instance, which then provides access to additional `Route` metadata by `RouteResult` consumers.
- marking of `Route` instances as supporting "implicit" `HEAD` and `OPTIONS` operations.

This patch thus does the following:

- Updates to zend-expressive-router 1.3.2+.
- Adds fig/http-message-util, for utilizing the `RequestMethodInterface` constants.
- Updates `AuraRouter` to marshal a `RouteResult` composing a `Route` instance on successful routing.
- Updates `AuraRouter` to consider a route failure a success if the path matches during a `HEAD` or `OPTIONS` request, when the method was not specified during creation.

These changes address zendframework/zend-expressive#398 for the Aura.Router implementation.