### PR TITLE
Add license checks to QA toolchain.

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,0 +1,5 @@
+/**
+ * @see       https://github.com/zendframework/zend-expressive-aurarouter for the canonical source repository
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-aurarouter/blob/master/LICENSE.md New BSD License
+ */

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 
 notifications:
-  email: true
+  irc: "irc.freenode.org#zftalk.dev"
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 script:
   - composer test
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 
 notifications:
   email: true

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7 || ^5.6",
-        "zendframework/zend-coding-standard": "~1.0.0"
+        "zendframework/zend-coding-standard": "~1.0.0",
+        "malukenho/docheader": "^0.1.5"
     },
     "autoload": {
       "psr-4": {
@@ -40,11 +41,13 @@
     },
     "scripts": {
         "check": [
+            "@license-check",
             "@cs-check",
             "@test"
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "license-check": "docheader check src/ test/",
         "test": "phpunit"
     }
 }

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ * @see       https://github.com/zendframework/zend-expressive-aurarouter for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-aurarouter/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Expressive\Router;

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ * @see       https://github.com/zendframework/zend-expressive-aurarouter for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-aurarouter/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Expressive\Router;


### PR DESCRIPTION
Adds malukenho/docheader as a dev requirement, along with a file docblock specification. Composer now defines a `license-check` script, which is also referenced in the `check` script, and in the travis configuration.

Two class files were updated to reflect the new requirements.