### PR TITLE
Ensure that when no HTTP methods are present non-implicit methods result in a 405

### DIFF
--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -434,4 +434,26 @@ class AuraRouterTest extends TestCase
         $this->assertTrue($result->isFailure());
         $this->assertFalse($result->isMethodFailure());
     }
+
+    public function testMatchWhenNoHttpMethodsPresentShouldResultInRoutingFailure()
+    {
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getPath()->willReturn('/foo');
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getUri()->willReturn($uri);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+        $request->getServerParams()->willReturn([]);
+
+        // Not mocking the router container or Aura\Route; this particular test
+        // is testing how the parts integrate.
+        $router = new AuraRouter();
+        $router->addRoute(new Route('/foo', 'foo', []));
+
+        $result = $router->match($request->reveal());
+        $this->assertInstanceOf(RouteResult::class, $result);
+        $this->assertTrue($result->isFailure(), 'Routing did not fail, but should have');
+        $this->assertTrue($result->isMethodFailure(), 'Failure was not due to HTTP method, but should have been');
+        $this->assertEquals([], $result->getAllowedMethods(), 'Allowed methods should have been empty, but was not');
+    }
 }


### PR DESCRIPTION
Discovered when doing integration tests from zendframework/zend-expressive#398.

Essentially, Aura.Router successfully matches a path if no methods are specified in the original route, when it should treat that as a 405 failure. We now check for an empty `$route->allows` array on a successful match, and, if so, treat it as a potential failure (potential, as `HEAD` and `OPTIONS` will be implicitly supported).