### PR TITLE
Ensure that when HTTP_METHOD_ANY is used, matching results in success

### DIFF
--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -456,4 +456,40 @@ class AuraRouterTest extends TestCase
         $this->assertTrue($result->isMethodFailure(), 'Failure was not due to HTTP method, but should have been');
         $this->assertEquals([], $result->getAllowedMethods(), 'Allowed methods should have been empty, but was not');
     }
+
+    public function allHttpMethods()
+    {
+        return [
+            [RequestMethod::METHOD_GET],
+            [RequestMethod::METHOD_POST],
+            [RequestMethod::METHOD_PUT],
+            [RequestMethod::METHOD_PATCH],
+            [RequestMethod::METHOD_DELETE],
+            [RequestMethod::METHOD_HEAD],
+            [RequestMethod::METHOD_OPTIONS],
+        ];
+    }
+
+    /**
+     * @dataProvider allHttpMethods
+     */
+    public function testWhenRouteAllowsAnyHttpMethodRouterShouldResultInSuccess($method)
+    {
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getPath()->willReturn('/foo');
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getUri()->willReturn($uri);
+        $request->getMethod()->willReturn($method);
+        $request->getServerParams()->willReturn([]);
+
+        // Not mocking the router container or Aura\Route; this particular test
+        // is testing how the parts integrate.
+        $router = new AuraRouter();
+        $router->addRoute(new Route('/foo', 'foo', Route::HTTP_METHOD_ANY));
+
+        $result = $router->match($request->reveal());
+        $this->assertInstanceOf(RouteResult::class, $result);
+        $this->assertTrue($result->isSuccess(), 'Routing failed, but should have succeeded');
+    }
 }


### PR DESCRIPTION
The changes introduced in #18 had a side-effect: when a route is created with `Route::HTTP_METHOD_ANY`, the `$allows` property of the associated `Aura\Route` is not populated. As such, we need to test for this scenario as well.