### PR TITLE
Adds support for zend-expressive-router 2.0

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-aurarouter for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-aurarouter/blob/master/LICENSE.md New BSD License
  */

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.6 || ^7.0",
         "aura/router": "^3.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.3.2",
+        "zendframework/zend-expressive-router": "^2.0",
         "fig/http-message-util": "^1.1"
     },
     "require-dev": {

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-aurarouter for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-aurarouter/blob/master/LICENSE.md New BSD License
  */
 
@@ -113,7 +113,7 @@ class AuraRouter implements RouterInterface
     /**
      * @inheritDoc
      */
-    public function generateUri($name, array $substitutions = [])
+    public function generateUri($name, array $substitutions = [], array $options = [])
     {
         // Must inject routes prior to generating URIs.
         $this->injectRoutes();


### PR DESCRIPTION
Updates the zend-expressive-router constraint to `^2.0`, and adds the new `$options` argument to `AuraRouter::generateUri()`; the new argument is ignored, as there is no support for additional or route-specific arguments in the Aura.Router implementation.