### PR TITLE
Removes ability to install v3 releases of zend-expressive-router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "aura/router": "^3.0.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^2.1 || ^3.0.0-dev || ^3.0.0"
+        "zendframework/zend-expressive-router": "^2.1"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "df448c34e8809e27eda290f7ece78b4a",
+    "content-hash": "1ef97aa9f61bf206c64a9459cbe9636b",
     "packages": [
         {
             "name": "aura/router",
@@ -155,6 +155,7 @@
                 "request",
                 "response"
             ],
+            "abandoned": "http-interop/http-server-middleware",
             "time": "2017-01-14T15:23:42+00:00"
         },
         {


### PR DESCRIPTION
The API of the `RouterInterface` changes in v3 to add scalar typehints as well as return typehints, which requires a minimum of PHP 7, and, in the case of `void` return types, PHP 7.1. As such, the current major version will not be compatible with the v3 release.