### PR TITLE
Updates to zend-expressive-router 3.0.0rc4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^3.0.0rc2"
+        "zendframework/zend-expressive-router": "^3.0.0rc3"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.6",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^3.0.0rc3"
+        "zendframework/zend-expressive-router": "^3.0.0rc4"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3377db6aa705d581be440eae3f9e6845",
+    "content-hash": "4e9d13c992b05bc65465dc08f52f41f4",
     "packages": [
         {
             "name": "aura/router",
@@ -359,16 +359,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0rc2",
+            "version": "3.0.0rc3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4"
+                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/97ea9940c72222586e832913529b097ddcc0b2e4",
-                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/c4380e07a96fede84e8eabbe2698120fa3df7332",
+                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332",
                 "shasum": ""
             },
             "require": {
@@ -421,7 +421,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-03-06T22:42:26+00:00"
+            "time": "2018-03-07T15:38:28+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e9d13c992b05bc65465dc08f52f41f4",
+    "content-hash": "dccc6c98fa8703f365f1ea4692fcaeff",
     "packages": [
         {
             "name": "aura/router",
@@ -359,16 +359,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0rc3",
+            "version": "3.0.0rc4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332"
+                "reference": "3b21fb4e1b568bfa8b0ae699b6f0bdd5d5644863"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/c4380e07a96fede84e8eabbe2698120fa3df7332",
-                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/3b21fb4e1b568bfa8b0ae699b6f0bdd5d5644863",
+                "reference": "3b21fb4e1b568bfa8b0ae699b6f0bdd5d5644863",
                 "shasum": ""
             },
             "require": {
@@ -421,7 +421,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-03-07T15:38:28+00:00"
+            "time": "2018-03-07T16:56:58+00:00"
         }
     ],
     "packages-dev": [

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -146,14 +146,7 @@ class AuraRouter implements RouterInterface
             return RouteResult::fromRouteFailure($failedRoute->allows);
         }
 
-        // Determine if the failed route allows ALL or NO HTTP methods
-        if ([] === $failedRoute->allows
-            && ! $this->matchAuraRouteToRoute($failedRoute)
-        ) {
-            return RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
-        }
-
-        return RouteResult::fromRouteFailure($failedRoute->allows ?: []);
+        return RouteResult::fromRouteFailure($failedRoute->allows ?: Route::HTTP_METHOD_ANY);
     }
 
     /**

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -443,28 +443,6 @@ class AuraRouterTest extends TestCase
         $this->assertFalse($result->isMethodFailure());
     }
 
-    public function testMatchWhenNoHttpMethodsPresentShouldResultInRoutingFailure()
-    {
-        $uri = $this->prophesize(UriInterface::class);
-        $uri->getPath()->willReturn('/foo');
-
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $request->getUri()->willReturn($uri);
-        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
-        $request->getServerParams()->willReturn([]);
-
-        // Not mocking the router container or Aura\Route; this particular test
-        // is testing how the parts integrate.
-        $router = new AuraRouter();
-        $router->addRoute(new Route('/foo', $this->getMiddleware(), []));
-
-        $result = $router->match($request->reveal());
-        $this->assertInstanceOf(RouteResult::class, $result);
-        $this->assertTrue($result->isFailure(), 'Routing did not fail, but should have');
-        $this->assertTrue($result->isMethodFailure(), 'Failure was not due to HTTP method, but should have been');
-        $this->assertEquals([], $result->getAllowedMethods(), 'Allowed methods should have been empty, but was not');
-    }
-
     public function allHttpMethods()
     {
         return [
@@ -516,7 +494,7 @@ class AuraRouterTest extends TestCase
         // Not mocking the router container or Aura\Route; this particular test
         // is testing how the parts integrate.
         $router = new AuraRouter();
-        $router->addRoute(new Route('/foo', $this->getMiddleware(), []));
+        $router->addRoute(new Route('/foo', $this->getMiddleware(), [RequestMethod::METHOD_TRACE]));
 
         $result = $router->match($request->reveal());
         $this->assertInstanceOf(RouteResult::class, $result);

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -274,7 +274,7 @@ class AuraRouterTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isFailure());
         $this->assertFalse($result->isMethodFailure());
-        $this->assertSame(['*'], $result->getAllowedMethods());
+        $this->assertSame(Route::HTTP_METHOD_ANY, $result->getAllowedMethods());
     }
 
     /**
@@ -321,7 +321,7 @@ class AuraRouterTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isFailure());
         $this->assertFalse($result->isMethodFailure());
-        $this->assertSame(['*'], $result->getAllowedMethods());
+        $this->assertSame(Route::HTTP_METHOD_ANY, $result->getAllowedMethods());
     }
 
     /**


### PR DESCRIPTION
rc3 modifies the `Route` constructor to no longer allow an empty set of HTTP methods. This eliminates the need for one test, and required a minor change to another (though the test still remains valid).